### PR TITLE
Add additional color schemes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 **v0.3.0**
 
-- Custom color schemes
-- Customizeable zoom out
+- More color schemes
 
 **v0.2.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.3.0**
+
+- Custom color schemes
+- Customizeable zoom out
 
 **v0.2.0**
 

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
 Higlass sequence track
 <div style=""></div>
 <div style="margin: auto">
-  <div style="height: 1500px; width: 800px; border: 1px solid black;"
+  <div style="height: 1500px; width: 600px; border: 1px solid black;"
        id="development-demo">
   </div>
 </div>
@@ -30,7 +30,7 @@ And some other text
 <script src="hglib.js"></script>
 <script>
   var viewConfig =
-  {
+{
   "editable": true,
   "zoomFixed": false,
   "trackSourceServers": [
@@ -57,47 +57,74 @@ And some other text
             "width": 20,
             "height": 30
           },
-          // {
-          //   "server": "http://localhost:8001/api/v1",
-          //   "tilesetUid": "ScrlBGMbR_WJ0fzKXxKFzA",
-          //   "uid": "multivecex",
-          //   "type": "horizontal-sequence",
-          //   "options": {
-          //     "colorAggregationMode": "max",
-          //     "labelPosition": "topLeft",
-          //     "labelColor": "black",
-          //     "labelTextOpacity": 0.4,
-          //     "valueScaling": "linear",
-          //     "trackBorderWidth": 0,
-          //     "trackBorderColor": "white",
-          //     "name": "hg38",
-          //     "backgroundColor": "white",
-          //     "barBorder": true,
-          //     "barBorderColor": "white",
-          //     "sortLargestOnTop": true,
-          //     "extendedPreloading": false,
-          //         // "colorScale": [ // A T G C N other
-          //         //   "#0000FF",
-          //         //   "#FFFFFF",
-          //         //   "#FFFFFF",
-          //         //   "#FF0000",
-          //         //   "#FFFFFF",
-          //         //   "#FFFFFF"
-          //         // ]
-          //     "colorScale": [ // A T G C N other
-          //       "#007FFF",
-          //       "#e8e500",
-          //       "#008000",
-          //       "#FF0038",
-          //       "#800080",
-          //       "#DCDCDC"
-          //     ]
-          //   },
-          //   "width": 568,
-          //   "height": 25
-          // },
           {
-            "uid": "fastaex",
+            "type": "combined",
+            "uid": "FkGY-Yv9T8avNXljXklukw",
+            "height": 25,
+            "width": 568,
+            "contents": [
+              {
+                "uid": "fastaex",
+                "type": "horizontal-sequence",
+                "data": {
+                  "type": "fasta",
+                  "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+                  "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+                  "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+                },
+                "options": {
+                  "colorAggregationMode": "none",
+                  "labelPosition": "topLeft",
+                  "labelColor": "black",
+                  "labelTextOpacity": 0.4,
+                  "valueScaling": "linear",
+                  "trackBorderWidth": 0,
+                  "trackBorderColor": "white",
+                  "name": "hg38",
+                  "backgroundColor": "white",
+                  "barBorder": true,
+                  "barBorderColor": "white",
+                  "sortLargestOnTop": true,
+                  "extendedPreloading": false,
+                  "colorScale": [
+                    "#007FFF",
+                    "#e8e500",
+                    "#008000",
+                    "#FF0038",
+                    "#800080",
+                    "#DCDCDC"
+                  ],
+                  "notificationText": "Zoom in to see nucleotides...",
+                  "fontSize": 16,
+                  "fontFamily": "Arial",
+                  "fontColor": "white",
+                  "textOption": {
+                    "fontSize": "32px",
+                    "fontFamily": "Arial",
+                    "fill": 16777215,
+                    "fontWeight": "bold"
+                  }
+                },
+                "width": 568,
+                "height": 25
+              },
+              {
+                "uid": "d6KeVfkNSmq_YNj_rWJgBA",
+                "type": "viewport-projection-horizontal",
+                "fromViewUid": "JaUMrYu4TkeP9RVS5QmpYg",
+                "options": {
+                  "projectionFillColor": "#777",
+                  "projectionStrokeColor": "#777",
+                  "projectionFillOpacity": 0.3,
+                  "projectionStrokeOpacity": 0.7,
+                  "strokeWidth": 1
+                }
+              }
+            ],
+            "options": {}
+          },
+          {
+            "uid": "fastaex1",
             "type": "horizontal-sequence",
             "data": {
               "type": "fasta",
@@ -119,14 +146,114 @@ And some other text
               "barBorderColor": "white",
               "sortLargestOnTop": true,
               "extendedPreloading": false,
-              "colorScale": [ // A T G C N other
-                "#007FFF",
-                "#e8e500",
-                "#008000",
-                "#FF0038",
-                "#800080",
+              "colorScale": [
+                "#22ca03",
+                "#c40003",
+                "#f6af08",
+                "#0000c7",
+                "#808080",
                 "#DCDCDC"
-              ]
+              ],
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
+            },
+            "width": 568,
+            "height": 25
+          },
+          {
+            "uid": "fastaex2",
+            "type": "horizontal-sequence",
+            "data": {
+              "type": "fasta",
+              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+            },
+            "options": {
+              "colorAggregationMode": "none",
+              "labelPosition": "topLeft",
+              "labelColor": "black",
+              "labelTextOpacity": 0.4,
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "white",
+              "name": "hg38",
+              "backgroundColor": "white",
+              "barBorder": true,
+              "barBorderColor": "white",
+              "sortLargestOnTop": true,
+              "extendedPreloading": false,
+              "colorScale": [
+                "#a6cee3",
+                "#1f78b4",
+                "#b2df8a",
+                "#33a02c",
+                "#808080",
+                "#DCDCDC"
+              ],
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
+            },
+            "width": 568,
+            "height": 25
+          },
+          {
+            "uid": "fastaex3",
+            "type": "horizontal-sequence",
+            "data": {
+              "type": "fasta",
+              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+            },
+            "options": {
+              "colorAggregationMode": "none",
+              "labelPosition": "topLeft",
+              "labelColor": "black",
+              "labelTextOpacity": 0.4,
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "white",
+              "name": "hg38",
+              "backgroundColor": "white",
+              "barBorder": true,
+              "barBorderColor": "white",
+              "sortLargestOnTop": true,
+              "extendedPreloading": false,
+              "colorScale": [
+                "#2c7bb6",
+                "#abd9e9",
+                "#ffffbf",
+                "#fdae61",
+                "#808080",
+                "#DCDCDC"
+              ],
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
             },
             "width": 568,
             "height": 25
@@ -155,22 +282,262 @@ And some other text
         "gallery": []
       },
       "initialXDomain": [
-        -2,
-        3
+        1080250.0490099243,
+        1081419.7532662181
       ],
       "initialYDomain": [
-        -2681066463.2605443,
-        -2681066462.780524
+        -2681119167.5682316,
+        -2681119130.5001388
       ],
       "layout": {
         "w": 12,
-        "h": 6,
+        "h": 10,
         "x": 0,
         "y": 0,
         "moved": false,
         "static": false
       },
       "uid": "AD_rIRKzRQKx3N8rbT9G4w"
+    },
+    {
+      "tracks": {
+        "top": [
+          {
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "NyITQvZsS_mOFNlz5C2LJg",
+            "uid": "Lb1oLu6rSiaIFcdrouucQg",
+            "type": "horizontal-chromosome-labels",
+            "options": {
+              "color": "#808080",
+              "stroke": "#ffffff",
+              "fontSize": 12,
+              "fontIsLeftAligned": false,
+              "showMousePosition": false,
+              "mousePositionColor": "#000000"
+            },
+            "width": 20,
+            "height": 30
+          },
+          {
+            "uid": "fastaex",
+            "type": "horizontal-sequence",
+            "data": {
+              "type": "fasta",
+              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+            },
+            "options": {
+              "colorAggregationMode": "none",
+              "labelPosition": "topLeft",
+              "labelColor": "black",
+              "labelTextOpacity": 0.4,
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "white",
+              "name": "hg38",
+              "backgroundColor": "white",
+              "barBorder": true,
+              "barBorderColor": "white",
+              "sortLargestOnTop": true,
+              "extendedPreloading": false,
+              "colorScale": [
+                "#007FFF",
+                "#e8e500",
+                "#008000",
+                "#FF0038",
+                "#800080",
+                "#DCDCDC"
+              ],
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
+            },
+            "width": 568,
+            "height": 25
+          },
+          {
+            "uid": "fastaex1",
+            "type": "horizontal-sequence",
+            "data": {
+              "type": "fasta",
+              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+            },
+            "options": {
+              "colorAggregationMode": "none",
+              "labelPosition": "topLeft",
+              "labelColor": "black",
+              "labelTextOpacity": 0.4,
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "white",
+              "name": "hg38",
+              "backgroundColor": "white",
+              "barBorder": true,
+              "barBorderColor": "white",
+              "sortLargestOnTop": true,
+              "extendedPreloading": false,
+              "colorScale": [
+                "#22ca03",
+                "#c40003",
+                "#f6af08",
+                "#0000c7",
+                "#808080",
+                "#DCDCDC"
+              ],
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
+            },
+            "width": 568,
+            "height": 25
+          },
+          {
+            "uid": "fastaex2",
+            "type": "horizontal-sequence",
+            "data": {
+              "type": "fasta",
+              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+            },
+            "options": {
+              "colorAggregationMode": "none",
+              "labelPosition": "topLeft",
+              "labelColor": "black",
+              "labelTextOpacity": 0.4,
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "white",
+              "name": "hg38",
+              "backgroundColor": "white",
+              "barBorder": true,
+              "barBorderColor": "white",
+              "sortLargestOnTop": true,
+              "extendedPreloading": false,
+              "colorScale": [
+                "#a6cee3",
+                "#1f78b4",
+                "#b2df8a",
+                "#33a02c",
+                "#808080",
+                "#DCDCDC"
+              ],
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
+            },
+            "width": 568,
+            "height": 25
+          },
+          {
+            "uid": "fastaex3",
+            "type": "horizontal-sequence",
+            "data": {
+              "type": "fasta",
+              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+            },
+            "options": {
+              "colorAggregationMode": "none",
+              "labelPosition": "topLeft",
+              "labelColor": "black",
+              "labelTextOpacity": 0.4,
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "white",
+              "name": "hg38",
+              "backgroundColor": "white",
+              "barBorder": true,
+              "barBorderColor": "white",
+              "sortLargestOnTop": true,
+              "extendedPreloading": false,
+              "colorScale": [
+                "#2c7bb6",
+                "#abd9e9",
+                "#ffffbf",
+                "#fdae61",
+                "#808080",
+                "#DCDCDC"
+              ],
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
+            },
+            "width": 568,
+            "height": 25
+          },
+          {
+            "server": "http://higlass.io/api/v1",
+            "uid": "emptytrack",
+            "type": "empty",
+            "options": {
+              "color": "#808080",
+              "stroke": "#ffffff",
+              "fontSize": 14,
+              "fontIsLeftAligned": false,
+              "showMousePosition": false,
+              "mousePositionColor": "#000000"
+            },
+            "width": 568,
+            "height": 200
+          }
+        ],
+        "left": [],
+        "center": [],
+        "right": [],
+        "bottom": [],
+        "whole": [],
+        "gallery": []
+      },
+      "initialXDomain": [
+        1080874.4140677315,
+        1080894.7455448946
+      ],
+      "initialYDomain": [
+        -2681120232.5512576,
+        -2681120231.90695
+      ],
+      "layout": {
+        "w": 12,
+        "h": 10,
+        "x": 0,
+        "y": 10,
+        "moved": false,
+        "static": false
+      },
+      "uid": "JaUMrYu4TkeP9RVS5QmpYg"
     }
   ],
   "zoomLocks": {

--- a/src/index.html
+++ b/src/index.html
@@ -522,10 +522,10 @@ And some other text
               "sortLargestOnTop": true,
               "extendedPreloading": false,
               "colorScale": [
-                "#2c7bb6",
-                "#abfff9",
-                "#ffffbf",
-                "#fdae61",
+                "#08519c",
+                "#6baed6",
+                "#993404",
+                "#fe9929",
                 "#808080",
                 "#DCDCDC"
               ],

--- a/src/index.html
+++ b/src/index.html
@@ -259,6 +259,51 @@ And some other text
             "height": 25
           },
           {
+            "uid": "fastaex4",
+            "type": "horizontal-sequence",
+            "data": {
+              "type": "fasta",
+              "fastaUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa",
+              "faiUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.fa.fai",
+              "chromSizesUrl": "https://aveit.s3.amazonaws.com/higlass/data/sequence/hg38.mod.chrom.sizes"
+            },
+            "options": {
+              "colorAggregationMode": "none",
+              "labelPosition": "topLeft",
+              "labelColor": "black",
+              "labelTextOpacity": 0.4,
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "white",
+              "name": "hg38",
+              "backgroundColor": "white",
+              "barBorder": true,
+              "barBorderColor": "white",
+              "sortLargestOnTop": true,
+              "extendedPreloading": false,
+              "colorScale": [
+                "#08519c",
+                "#6baed6",
+                "#993404",
+                "#fe9929",
+                "#808080",
+                "#DCDCDC"
+              ],
+              "notificationText": "Zoom in to see nucleotides...",
+              "fontSize": 16,
+              "fontFamily": "Arial",
+              "fontColor": "white",
+              "textOption": {
+                "fontSize": "32px",
+                "fontFamily": "Arial",
+                "fill": 16777215,
+                "fontWeight": "bold"
+              }
+            },
+            "width": 568,
+            "height": 25
+          },
+          {
             "server": "http://higlass.io/api/v1",
             "uid": "emptytrack",
             "type": "empty",
@@ -478,7 +523,7 @@ And some other text
               "extendedPreloading": false,
               "colorScale": [
                 "#2c7bb6",
-                "#abd9e9",
+                "#abfff9",
                 "#ffffbf",
                 "#fdae61",
                 "#808080",

--- a/src/scripts/SequenceTrack.js
+++ b/src/scripts/SequenceTrack.js
@@ -864,13 +864,13 @@ SequenceTrack.config = {
     fontColor: "white",
     colorScale: [
       // A T G C N other
-      "#007FFF",
-      "#e8e500",
-      "#008000",
-      "#FF0038",
-      "#800080",
+      "#2c7bb6",
+      "#abd9e9",
+      "#ffffbf",
+      "#fdae61",
+      "#808080",
       "#DCDCDC",
-    ],
+    ]
   },
     optionsInfo: {
     colorScale: {
@@ -886,7 +886,7 @@ SequenceTrack.config = {
               "#800080",
               "#DCDCDC",
             ],
-          name: 'Default',
+          name: 'DRuMS',
         },
         logos: {
           value: [

--- a/src/scripts/SequenceTrack.js
+++ b/src/scripts/SequenceTrack.js
@@ -103,7 +103,7 @@ const SequenceTrack = (HGC, ...args) => {
       tile.textGraphics = new HGC.libraries.PIXI.Graphics();
       tile.rectGraphics = new HGC.libraries.PIXI.Graphics();
       tile.borderGraphics = new HGC.libraries.PIXI.Graphics();
-      tile.tempGraphics = new HGC.libraries.PIXI.Graphics();
+      tile.tempGraphics =   new HGC.libraries.PIXI.Graphics();
 
       tile.graphics.addChild(tile.rectGraphics);
       tile.graphics.addChild(tile.textGraphics);
@@ -914,13 +914,12 @@ SequenceTrack.config = {
         },
         bluesBeiges: {
           value: [
-              // A T G C N other
-              "#2c7bb6",
-              "#abd9e9",
-              "#ffffbf",
-              "#fdae61",
+              "#08519c",
+              "#6baed6",
+              "#993404",
+              "#fe9929",
               "#808080",
-              "#DCDCDC",
+              "#DCDCDC"
             ],
           name: 'Blues / Beiges (CB friendly)',
         },

--- a/src/scripts/SequenceTrack.js
+++ b/src/scripts/SequenceTrack.js
@@ -26,7 +26,9 @@ const SequenceTrack = (HGC, ...args) => {
       this.dataFetchingMode = context.dataConfig.type;
 
       this.updateOptions(this.options);
+    }
 
+    setPixiTexts() {
       this.pixiTexts = [];
       const letters = ["A", "T", "G", "C", "N", " "];
       this.letterWidths = [];
@@ -89,6 +91,7 @@ const SequenceTrack = (HGC, ...args) => {
       this.barBorderColor = colorToHex(newOptions.barBorderColor);
 
       this.localColorToHexScale();
+      this.setPixiTexts();
     }
 
     initTile(tile) {
@@ -105,15 +108,6 @@ const SequenceTrack = (HGC, ...args) => {
       tile.graphics.addChild(tile.rectGraphics);
       tile.graphics.addChild(tile.textGraphics);
       tile.graphics.addChild(tile.borderGraphics);
-
-      tile.colorAndLetterData.forEach((td, i) => {
-        const letter = td.letter;
-
-        tile.texts[i] = new HGC.libraries.PIXI.Sprite(this.pixiTexts[letter]);
-        tile.texts[i].width = this.letterWidths[letter];
-        tile.texts[i].height = this.letterHeights[letter];
-        tile.texts[i].letter = letter;
-      });
 
       // stores which zoomLevel the tile belongs to. Needed for extendedPreloading
       tile.zoomLevel = parseInt(tile.tileId.split(".")[0], 10);
@@ -433,6 +427,15 @@ const SequenceTrack = (HGC, ...args) => {
     }
 
     drawTextSequence(tileX, tileWidth, tile) {
+      tile.colorAndLetterData.forEach((td, i) => {
+        const letter = td.letter;
+
+        tile.texts[i] = new HGC.libraries.PIXI.Sprite(this.pixiTexts[letter]);
+        tile.texts[i].width = this.letterWidths[letter];
+        tile.texts[i].height = this.letterHeights[letter];
+        tile.texts[i].letter = letter;
+      });
+
       const trackHeight = this.dimensions[1];
 
       const matrix = tile.colorAndLetterData;
@@ -551,7 +554,7 @@ const SequenceTrack = (HGC, ...args) => {
         // For fasta files maxZoom is equal to the hightest zoom level
         // Therefore the notification is shown only two levels below highest zoom level
         // We leave it like that intentionally for now.
-        this.zoomLevel < this.maxZoom - 1 &&
+        this.zoomLevel < this.maxZoom - 3 &&
         this.options.colorAggregationMode === "none"
       ) {
         this.showNotification();
@@ -709,7 +712,7 @@ const SequenceTrack = (HGC, ...args) => {
       );
 
       if (
-        this.zoomLevel < this.maxZoom - 1 &&
+        this.zoomLevel < this.maxZoom - 3 &&
         this.options.colorAggregationMode === "none"
       ) {
         const rect = document.createElement("rect");
@@ -869,6 +872,61 @@ SequenceTrack.config = {
       "#DCDCDC",
     ],
   },
+    optionsInfo: {
+    colorScale: {
+      name: 'Color scheme',
+      inlineOptions: {
+        default: {
+          value: [
+              // A T G C N other
+              "#007FFF",
+              "#e8e500",
+              "#008000",
+              "#FF0038",
+              "#800080",
+              "#DCDCDC",
+            ],
+          name: 'Default',
+        },
+        logos: {
+          value: [
+              // A T G C N other
+              "#22ca03",
+              "#c40003",
+              "#f6af08",
+              "#0000c7",
+              "#808080",
+              "#DCDCDC",
+            ],
+          name: 'Logos / IGV',
+        },
+        bluesGreens: {
+          value: [
+              // A T G C N other
+              "#a6cee3",
+              "#1f78b4",
+              "#b2df8a",
+              "#33a02c",
+              "#808080",
+              "#DCDCDC",
+            ],
+          name: 'Blues / Greens  (CB friendly)',
+        },
+        bluesBeiges: {
+          value: [
+              // A T G C N other
+              "#2c7bb6",
+              "#abd9e9",
+              "#ffffbf",
+              "#fdae61",
+              "#808080",
+              "#DCDCDC",
+            ],
+          name: 'Blues / Beiges (CB friendly)',
+        },
+      },
+  },
+}
 };
 
 export default SequenceTrack;


### PR DESCRIPTION
This PR adds a few more color schemes and increases the amount that one can zoom out before being prompted to zoom in.

**This PR changes the default to Blues / Beiges which is the last scheme in the screenshot below**. Let me know if you don't want that.

The Blues / Beiges colorscheme is, IMO, better because it clearly distinguishes A and T (blues) from C and G (beiges) so if you zoom out you get an idea of GC content. It's also colorblind friendly.

<img width="590" alt="image" src="https://user-images.githubusercontent.com/2143629/93507878-50cffe00-f8ec-11ea-93bc-a509722425bb.png">
